### PR TITLE
Pass mailParserOptions to mailparser

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class MailListener extends EventEmitter {
               attrs = a;
             });
             msg.on('body', async (stream, info) => {
-              let parsed = await simpleParser(stream);
+              let parsed = await simpleParser(stream, this.mailParserOptions);
               self.emit('mail', parsed, seqno, attrs);
               self.emit('headers', parsed.headers, seqno, attrs);
               self.emit('body', { html: parsed.html, text: parsed.text, textAsHtml: parsed.textAsHtml }, seqno, attrs);

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,8 @@ var mailListener = new MailListener({
   markSeen: true, // all fetched email willbe marked as seen and not fetched next time
   fetchUnreadOnStart: true, // use it only if you want to get all unread email on lib start. Default is `false`,
   attachments: true, // download attachments as they are encountered to the project directory
-  attachmentOptions: { directory: "attachments/" } // specify a download directory for attachments
+  attachmentOptions: { directory: "attachments/" }, // specify a download directory for attachments
+  mailParserOptions: {} //options for mailparser
 });
 
 mailListener.start(); // start listening


### PR DESCRIPTION
mailParserOptions are already set in constructor, but not passed to simpleParser 